### PR TITLE
Ability to cancel bulk operations

### DIFF
--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -5,6 +5,7 @@ import {
   OPERATION_BY_ID,
   CREATE_PRODUCTS_OPERATION,
   CREATE_ORDERS_OPERATION,
+  CANCEL_OPERATION,
   incrementalProductsQuery,
   incrementalOrdersQuery,
 } from "./queries";
@@ -18,7 +19,7 @@ export interface BulkOperationRunQueryResponse {
   };
 }
 
-const finishedStatuses = [`COMPLETED`, `FAILED`];
+const finishedStatuses = [`COMPLETED`, `FAILED`, `CANCELED`];
 
 export function createOperations(options: ShopifyPluginOptions) {
   const client = createClient(options);
@@ -35,6 +36,7 @@ export function createOperations(options: ShopifyPluginOptions) {
 
   async function finishLastOperation(): Promise<void> {
     const { currentBulkOperation } = await currentOperation();
+    console.info(currentBulkOperation);
     if (currentBulkOperation && currentBulkOperation.id) {
       if (finishedStatuses.includes(currentBulkOperation.status)) {
         return;
@@ -59,6 +61,7 @@ export function createOperations(options: ShopifyPluginOptions) {
       id: operationId,
     });
 
+    console.info(operation);
     if (operation.node.status === "FAILED") {
       throw operation;
     }
@@ -87,6 +90,10 @@ export function createOperations(options: ShopifyPluginOptions) {
 
     createOrdersOperation() {
       return createOperation(CREATE_ORDERS_OPERATION);
+    },
+
+    cancelOperation(id: string) {
+      return client.request(CANCEL_OPERATION, { id });
     },
 
     finishLastOperation,

--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -32,6 +32,20 @@ query OPERATION_BY_ID($id: ID!) {
 }
 `;
 
+export const CANCEL_OPERATION = `
+mutation CANCEL_OPERATION($id: ID!) {
+  bulkOperationCancel(id: $id) {
+    bulkOperation {
+      status
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+`;
+
 function bulkOperationQuery(query: string) {
   return `
     mutation {


### PR DESCRIPTION
This is to help with scenarios where e.g. a build is cancelled and a new one is started while a bulk operation is still in progress. In these scenarios, the new build could potentially wait a long time for the previous operation, so cancelling that should offer a speed boost.

Note that it does not stand up well to the refresh endpoint being spammed. In a case like that, two builds could be simultaneously waiting for the cancelling operation to terminate, and then try to fire off a new bulk operation request at the same moment. (This shouldn't be an issue in Cloud).