### PR TITLE
Fix incremental queries to properly quote date strings

### DIFF
--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -71,7 +71,7 @@ const ordersQuery = (dateString?: string) => `
 {
   orders${
     dateString
-      ? `(query: "created_at:>=${dateString} OR updated_at:>=${dateString}")`
+      ? `(query: "created_at:>='${dateString}' OR updated_at:>='${dateString}'")`
       : ``
   } {
     edges {
@@ -104,7 +104,7 @@ const productsQuery = (dateString?: string) => `
 {
   products${
     dateString
-      ? `(query: "created_at:>=${dateString} OR updated_at:>=${dateString}")`
+      ? `(query: "created_at:>='${dateString}' OR updated_at:>='${dateString}'")`
       : ``
   } {
     edges {


### PR DESCRIPTION
Encloses the date strings with quotes for Product and Order incremental queries.

Incremental builds were not returning data before this change. After I can confirm that Shopify sends the webhook, the data is processed locally, and the data is correct in Gatsby's local graphiql explorer.