### PR TITLE
Inc build bug - parse date string

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.0.0",
+  "version": "1.11.1",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -190,7 +190,7 @@ async function sourceChangedNodes(
     finishLastOperation,
     completedOperation,
   } = createOperations(pluginOptions, gatsbyApi);
-  const lastBuildTime = await gatsbyApi.cache.get(`LAST_BUILD_TIME`);
+  const lastBuildTime = new Date(await gatsbyApi.cache.get(`LAST_BUILD_TIME`));
   for (const nodeType of shopifyNodeTypes) {
     gatsbyApi
       .getNodesByType(nodeType)
@@ -218,7 +218,7 @@ async function sourceChangedNodes(
   }
 
   const { fetchDestroyEventsSince } = eventsApi(pluginOptions);
-  const destroyEvents = await fetchDestroyEventsSince(new Date(lastBuildTime));
+  const destroyEvents = await fetchDestroyEventsSince(lastBuildTime);
   if (destroyEvents.length) {
     for (const nodeType of shopifyNodeTypes) {
       gatsbyApi.getNodesByType(nodeType).forEach((node) => {


### PR DESCRIPTION
Inc builds were failing after a recent refactor because date strings were being passed into the incremental operations, rather than actual dates.