### PR TITLE
Improve wait time reporting to include operation ID and status

### DIFF
--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -63,12 +63,7 @@ function makeSourceFromOperation(
         createContentDigest,
       });
 
-      const waitTimer = reporter.activityTimer(
-        `Check for operations in progress`
-      );
-      waitTimer.start();
       await finishLastOperation();
-      waitTimer.end();
 
       reporter.info(`Initiating bulk operation query`);
       const {

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -72,24 +72,19 @@ export function createOperations(
   }
 
   async function finishLastOperation(): Promise<void> {
-    const { currentBulkOperation } = await currentOperation();
+    let { currentBulkOperation } = await currentOperation();
     if (currentBulkOperation && currentBulkOperation.id) {
-      if (options.verboseLogging) {
-        reporter.verbose(`
-        Waiting for previous operation
+      const timer = reporter.activityTimer(
+        `Waiting for operation ${currentBulkOperation.id} : ${currentBulkOperation.status}`
+      );
+      timer.start();
 
-        ${currentBulkOperation.id}
-
-        Status: ${currentBulkOperation.status}
-      `);
+      while (!finishedStatuses.includes(currentBulkOperation.status)) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        currentBulkOperation = (await currentOperation()).currentBulkOperation;
       }
 
-      if (finishedStatuses.includes(currentBulkOperation.status)) {
-        return;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      return finishLastOperation();
+      timer.end();
     }
   }
   /* Maybe the interval should be adjustable, because users

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -82,6 +82,11 @@ export function createOperations(
       while (!finishedStatuses.includes(currentBulkOperation.status)) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         currentBulkOperation = (await currentOperation()).currentBulkOperation;
+        if (options.verboseLogging) {
+          reporter.verbose(
+            `Polling operation ${currentBulkOperation.id} : ${currentBulkOperation.status}`
+          );
+        }
       }
 
       timer.end();


### PR DESCRIPTION
This way if we are waiting for a long time for someone else's operation to complete, we'll also report the ID of that operation as well as what the status was when it was first found.